### PR TITLE
Updated devtoolsFrontendUrl to match Chrome 38+ DevTools

### DIFF
--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1726,7 +1726,7 @@ char *iwdp_ipages_to_text(iwdp_ipage_t *ipages, bool want_json,
     iwdp_ipage_t ipage = *ipp;
     char *href = NULL;
     if (frontend_url) {
-      if (asprintf(&href, "%s?host=%s:%d&page=%d", frontend_url,
+      if (asprintf(&href, "%s?ws=%s:%d/devtools/page/%d", frontend_url,
           (host ? host : "localhost"), port, ipage->page_num) < 0) {
         return NULL;  // asprintf failed
       }


### PR DESCRIPTION
This is an update to the `devtoolsFrontendUrl` property in the /json response, as Chrome 38+ DevTools has changed how the websocket is passed to it.

Before
`chrome-devtools://devtools/bundled/devtools.html?host=<url>:port&page=<page>``

After
`chrome-devtools://devtools/bundled/devtools.html?ws=<url>:<port>/devtools/page/<page>`

This fixes #78, and make the proxy work in Chrome 43.
